### PR TITLE
Fix filtering of articles in more categories

### DIFF
--- a/pages/articles/category/[category]/index.tsx
+++ b/pages/articles/category/[category]/index.tsx
@@ -115,7 +115,7 @@ const ArticlesPage: FC<Props> = props => {
       return props.articles;
     } else {
       return props.articles.filter(
-        article => article.elements.articleType.value[0]?.codename === category
+        article => article.elements.articleType.value.some(type => type.codename === category)
       );
     }
   };


### PR DESCRIPTION
### Motivation

Internal link: DEVREL-847

Remove the hardcoded check for category selection - this worked fine only when the filtered category was one, or on the first place.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Reopen as filtering in articles by research does show Nanoblade article (has "Research" as a second category)
